### PR TITLE
Re-introduce constructor without useWholeImage parameter

### DIFF
--- a/src/main/java/net/preibisch/stitcher/algorithm/PairwiseStitchingParameters.java
+++ b/src/main/java/net/preibisch/stitcher/algorithm/PairwiseStitchingParameters.java
@@ -38,6 +38,12 @@ public class PairwiseStitchingParameters
 	}
 
 	public PairwiseStitchingParameters(double minOverlap, int peaksToCheck, boolean doSubpixel,
+		boolean interpolateCrossCorrelation, boolean showExpertGrouping)
+	{
+		this(minOverlap, peaksToCheck, doSubpixel, interpolateCrossCorrelation, showExpertGrouping, false);
+	}
+
+	public PairwiseStitchingParameters(double minOverlap, int peaksToCheck, boolean doSubpixel,
 			boolean interpolateCrossCorrelation, boolean showExpertGrouping, boolean useWholeImage )
 	{
 		this.minOverlap = minOverlap;


### PR DESCRIPTION
Guys, how can you work when your `master` branch doesn't build? ;-)

This PR adds back the constructor signature that was removed in bddecbd.
Without a `useWholeImage` parameter supplied, we default to `false`, as this was the default behavior before the parameter was added.

Independent of this, the places that were broken in bddecbd can be fixed [here](https://github.com/PreibischLab/BigStitcher/blob/ec7708fb6291e3fddde127abce6ea6f645145f4e/src/main/java/net/preibisch/stitcher/headless/registration/TestGlobalOptTwoRound.java#L94) and [here](https://github.com/PreibischLab/BigStitcher/blob/ec7708fb6291e3fddde127abce6ea6f645145f4e/src/main/java/net/preibisch/stitcher/headless/StitchingPairwise.java#L81), but I suggest to also keep the constructor signature re-introduced here, as it was public API.
