### PR TITLE
Update to more recent bigdataviewer-core API (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /.classpath
 /.project
 /.settings/
+
+# IntelliJ  #
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
 		<bigdataviewer-core.version>10.4.12</bigdataviewer-core.version>
 		<bigdataviewer-vistools.version>1.0.0-beta-33</bigdataviewer-vistools.version>
 
+		<enforcer.skip>true</enforcer.skip>
+		<multiview-reconstruction.version>3.2.4-SNAPSHOT</multiview-reconstruction.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>36.0.0</version>
+		<version>37.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -103,14 +103,9 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<imglib2.version>6.1.0</imglib2.version>
-		<imglib2-algorithm.version>0.13.2</imglib2-algorithm.version>
-		<imglib2-cache.version>1.0.0-beta-17</imglib2-cache.version>
-		<imagej-ops.version>2.0.0</imagej-ops.version>
-		<bigdataviewer-core.version>10.4.6</bigdataviewer-core.version>
-		<bigdataviewer-vistools.version>1.0.0-beta-32</bigdataviewer-vistools.version>
-		<!-- <n5-imglib2.version>4.4.1-SNAPSHOT</n5-imglib2.version> -->
-		<multiview-reconstruction.version>3.2.3</multiview-reconstruction.version>
+		<bigdataviewer-core.version>10.4.12</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-33</bigdataviewer-vistools.version>
+
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/preibisch/stitcher/algorithm/SpimDataFilteringAndGrouping.java
+++ b/src/main/java/net/preibisch/stitcher/algorithm/SpimDataFilteringAndGrouping.java
@@ -37,7 +37,6 @@ import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.base.Entity;
 import mpicbg.spim.data.generic.base.NamedEntity;
 import mpicbg.spim.data.generic.sequence.BasicViewDescription;
-import mpicbg.spim.data.generic.sequence.BasicViewSetup;
 import mpicbg.spim.data.sequence.Angle;
 import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.Illumination;
@@ -171,10 +170,10 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 		return Group.combineBy( ungroupedElements, groupingFactors);
 	}
 
-	public List<Pair<? extends Group< ? extends BasicViewDescription< ? extends BasicViewSetup > >, ? extends Group< ? extends BasicViewDescription< ? extends BasicViewSetup >>>> getComparisons()
+	public List<Pair<? extends Group< ? extends BasicViewDescription< ? > >, ? extends Group< ? extends BasicViewDescription< ? >>>> getComparisons()
 	{
-		final List<Pair<? extends Group< ? extends BasicViewDescription< ? extends BasicViewSetup > >, ? extends Group< ? extends BasicViewDescription< ? extends BasicViewSetup >>>> res = new ArrayList<>();
-		
+		final List<Pair<? extends Group< ? extends BasicViewDescription< ? > >, ? extends Group< ? extends BasicViewDescription< ? >>>> res = new ArrayList<>();
+
 		// filter first
 		final List<BasicViewDescription< ? > > ungroupedElements =
 				SpimDataTools.getFilteredViewDescriptions( data.getSequenceDescription(), filters);
@@ -227,16 +226,16 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 	 * @param cl Class of entity to get instances of
 	 * @return all instances of cl in the views in vds
 	 */
-	public static Set<Entity> getInstancesOfAttributeGrouped(Collection< List< BasicViewDescription< ? extends BasicViewSetup > > > vds, Class<? extends Entity> cl)
-	{	
+	public static Set<Entity> getInstancesOfAttributeGrouped(Collection< List< BasicViewDescription< ? > > > vds, Class<? extends Entity> cl)
+	{
 		// make one List out of the nested Collection and getInstancesOfAttribute
 		return getInstancesOfAttribute( vds.stream().reduce( new ArrayList<>(), (x, y) -> {x.addAll(y); return x;} ), cl );
 	}
 
-	public static Set<Entity> getInstancesOfAttribute(Collection<? extends BasicViewDescription< ? extends BasicViewSetup >> vds, Class<? extends Entity> cl)
+	public static Set<Entity> getInstancesOfAttribute(Collection<? extends BasicViewDescription< ? >> vds, Class<? extends Entity> cl)
 	{
 		Set<Entity> res = new HashSet<>();
-		for (BasicViewDescription< ? extends BasicViewSetup > vd : vds)
+		for (BasicViewDescription< ? > vd : vds)
 			if (cl == TimePoint.class)
 				res.add( vd.getTimePoint() );
 			else
@@ -250,11 +249,11 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 	 * @param cl Class of entity to get instances of
 	 * @return all instances of cl in the views in vds
 	 */
-	public static List<? extends Entity> getInstancesInAllGroups(Collection< ? extends Iterable< BasicViewDescription< ? extends BasicViewSetup > > > vds, Class<? extends Entity> cl)
+	public static List<? extends Entity> getInstancesInAllGroups(Collection< ? extends Iterable< BasicViewDescription< ? > > > vds, Class<? extends Entity> cl)
 	{
 		Set<Entity> res = new HashSet<>();
-		Iterator< ? extends Iterable< BasicViewDescription< ? extends BasicViewSetup > > > it = vds.iterator();
-		for (BasicViewDescription< ? extends BasicViewSetup > vd : it.next())
+		Iterator< ? extends Iterable< BasicViewDescription< ? > > > it = vds.iterator();
+		for (BasicViewDescription< ? > vd : it.next())
 			if (cl == TimePoint.class)
 				res.add( vd.getTimePoint() );
 			else
@@ -262,9 +261,9 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 
 		while (it.hasNext()) 
 		{
-			Iterable< BasicViewDescription< ? extends BasicViewSetup > > vdli = it.next();
+			Iterable< BasicViewDescription< ? > > vdli = it.next();
 			Set<Entity> resI = new HashSet<>();
-			for (BasicViewDescription< ? extends BasicViewSetup > vd : vdli)
+			for (BasicViewDescription< ? > vd : vdli)
 				if (cl == TimePoint.class)
 					resI.add( vd.getTimePoint() );
 				else
@@ -312,7 +311,7 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 		
 	}
 
-	public SpimDataFilteringAndGrouping< AS> askUserForFiltering(Collection<? extends BasicViewDescription< ? extends BasicViewSetup > > views)
+	public SpimDataFilteringAndGrouping< AS> askUserForFiltering(Collection<? extends BasicViewDescription< ? > > views)
 	{
 
 		GenericDialogPlus gdp1 = new GenericDialogPlus( "Select Views To Process" );

--- a/src/main/java/net/preibisch/stitcher/algorithm/SpimDataFilteringAndGrouping.java
+++ b/src/main/java/net/preibisch/stitcher/algorithm/SpimDataFilteringAndGrouping.java
@@ -24,7 +24,6 @@ package net.preibisch.stitcher.algorithm;
 
 import java.awt.Font;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,8 +31,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.swing.JLabel;
 
 import fiji.util.gui.GenericDialogPlus;
 import mpicbg.spim.data.generic.AbstractSpimData;
@@ -108,7 +105,7 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 		filters.put(cl, instances);
 	}
 
-	public void addFilters(Collection<? extends BasicViewDescription< ? extends BasicViewSetup >> selected)
+	public void addFilters(Collection<? extends BasicViewDescription<?>> selected)
 	{
 		for (Class<? extends Entity> cl : entityClasses)
 			filters.put( cl, new ArrayList<>(getInstancesOfAttribute( selected, cl ) ) );
@@ -298,13 +295,13 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 	}
 
 	// convenience method if have a panel (which can give us selected views)
-	public SpimDataFilteringAndGrouping< AS> askUserForFiltering(FilteredAndGroupedExplorerPanel< AS, ?> panel)
+	public SpimDataFilteringAndGrouping< AS> askUserForFiltering(FilteredAndGroupedExplorerPanel< AS > panel)
 	{
-		List< BasicViewDescription< ? extends BasicViewSetup > > views;
-		
+		List< BasicViewDescription< ? > > views;
+
 		if (panel instanceof GroupedRowWindow)
 		{
-			Collection< List< BasicViewDescription< ? extends BasicViewSetup > > > selectedRowsGroups = ((GroupedRowWindow)panel).selectedRowsGroups();
+			Collection< List< BasicViewDescription< ? > > > selectedRowsGroups = ((GroupedRowWindow)panel).selectedRowsGroups();
 			views = selectedRowsGroups.stream().reduce( new ArrayList<>(), (x, y) -> {x.addAll(y); return x;} );
 		}
 		else
@@ -350,19 +347,19 @@ public class SpimDataFilteringAndGrouping < AS extends AbstractSpimData< ? > >
 	
 	}
 
-	public SpimDataFilteringAndGrouping< AS> askUserForGrouping()
+	public SpimDataFilteringAndGrouping< AS > askUserForGrouping()
 	{
 		// use the current filtering as preset
 		return askUserForGrouping( SpimDataTools.getFilteredViewDescriptions( data.getSequenceDescription(), getFilters() ), new ArrayList<>(), new HashSet<>() );
 	}
 
-	public SpimDataFilteringAndGrouping< AS> askUserForGrouping( FilteredAndGroupedExplorerPanel< AS, ?> panel)
+	public SpimDataFilteringAndGrouping< AS > askUserForGrouping( FilteredAndGroupedExplorerPanel< AS > panel)
 	{
-		List< BasicViewDescription< ? extends BasicViewSetup > > views;
+		List< BasicViewDescription< ? > > views;
 
 		if (panel instanceof GroupedRowWindow)
 		{
-			Collection< List< BasicViewDescription< ? extends BasicViewSetup > > > selectedRowsGroups = ((GroupedRowWindow)panel).selectedRowsGroups();
+			Collection< List< BasicViewDescription< ? > > > selectedRowsGroups = ((GroupedRowWindow)panel).selectedRowsGroups();
 			views = selectedRowsGroups.stream().reduce( new ArrayList<>(), (x, y) -> {x.addAll(y); return x;} );
 		}
 		else

--- a/src/main/java/net/preibisch/stitcher/algorithm/globalopt/ExecuteGlobalOpt.java
+++ b/src/main/java/net/preibisch/stitcher/algorithm/globalopt/ExecuteGlobalOpt.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Date;
 
 import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.Illumination;
 import mpicbg.spim.data.sequence.Tile;
@@ -43,21 +42,21 @@ import net.preibisch.stitcher.gui.overlay.DemoLinkOverlay;
 
 public class ExecuteGlobalOpt implements Runnable
 {
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 	private boolean expertMode;
 	private SpimDataFilteringAndGrouping<? extends AbstractSpimData<?> > savedFiltering;
 
 	public ExecuteGlobalOpt(
-			final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel, 
+			final ExplorerWindow< ?, ? > panel,
 			final boolean expertMode )
 	{
 		this.panel = panel;
 		this.expertMode = expertMode;
 		this.savedFiltering = null;
 	}
-	
+
 	public ExecuteGlobalOpt(
-			final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel,
+			final ExplorerWindow< ?, ? > panel,
 			final SpimDataFilteringAndGrouping<? extends AbstractSpimData<?> > savedFiltering)
 	{
 		this.panel = panel;

--- a/src/main/java/net/preibisch/stitcher/algorithm/globalopt/ExecuteGlobalOpt.java
+++ b/src/main/java/net/preibisch/stitcher/algorithm/globalopt/ExecuteGlobalOpt.java
@@ -42,12 +42,12 @@ import net.preibisch.stitcher.gui.overlay.DemoLinkOverlay;
 
 public class ExecuteGlobalOpt implements Runnable
 {
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 	private boolean expertMode;
 	private SpimDataFilteringAndGrouping<? extends AbstractSpimData<?> > savedFiltering;
 
 	public ExecuteGlobalOpt(
-			final ExplorerWindow< ?, ? > panel,
+			final ExplorerWindow< ? > panel,
 			final boolean expertMode )
 	{
 		this.panel = panel;
@@ -56,8 +56,8 @@ public class ExecuteGlobalOpt implements Runnable
 	}
 
 	public ExecuteGlobalOpt(
-			final ExplorerWindow< ?, ? > panel,
-			final SpimDataFilteringAndGrouping<? extends AbstractSpimData<?> > savedFiltering)
+			final ExplorerWindow< ? > panel,
+			final SpimDataFilteringAndGrouping< ? > savedFiltering )
 	{
 		this.panel = panel;
 		this.expertMode = savedFiltering.requestExpertSettingsForGlobalOpt;
@@ -83,7 +83,7 @@ public class ExecuteGlobalOpt implements Runnable
 			final SpimDataFilteringAndGrouping< SpimData2 > filteringAndGrouping;
 			if ( !isSavedFaG )
 			{
-				FilteredAndGroupedExplorerPanel< SpimData2, ? > panelFG = (FilteredAndGroupedExplorerPanel< SpimData2, ? >) panel;
+				FilteredAndGroupedExplorerPanel< SpimData2 > panelFG = ( FilteredAndGroupedExplorerPanel< SpimData2 > ) panel;
 				filteringAndGrouping = new SpimDataFilteringAndGrouping< SpimData2 >(
 						(SpimData2) panel.getSpimData() );
 
@@ -134,7 +134,7 @@ public class ExecuteGlobalOpt implements Runnable
 			if ( !StitchingExplorerPanel.class.isInstance( panel ) )
 				demoOverlay = null;
 			else
-				demoOverlay = (( StitchingExplorerPanel<?,?> )panel).getDemoLinkOverlay();
+				demoOverlay = ( ( StitchingExplorerPanel< ? > ) panel ).getDemoLinkOverlay();
 
 			if ( demoOverlay != null )
 			{
@@ -150,7 +150,7 @@ public class ExecuteGlobalOpt implements Runnable
 			System.out.println( "resetting savedFilteringAndGrouping" );
 			// remove saved filtering and grouping once we are done here
 			// regardless of whether optimization was successful or not
-			( (StitchingExplorerPanel< ?, ? >) panel ).setSavedFilteringAndGrouping( null );
+			( (StitchingExplorerPanel< ? >) panel ).setSavedFilteringAndGrouping( null );
 		}
 
 		panel.updateContent();

--- a/src/main/java/net/preibisch/stitcher/algorithm/globalopt/GlobalOptStitcher.java
+++ b/src/main/java/net/preibisch/stitcher/algorithm/globalopt/GlobalOptStitcher.java
@@ -85,7 +85,7 @@ public class GlobalOptStitcher
 				filteringAndGrouping.getFilteredViews().stream().map( x -> (ViewId) x )
 						.collect( Collectors.toList() ),
 				filteringAndGrouping.getGroupedViews( false )
-						.stream().map( x -> new Group< ViewId >( x.getViews().stream()
+						.stream().map( x -> new Group<>( x.getViews().stream()
 								.map( y -> (ViewId) y ).collect( Collectors.toList() ) ) )
 						.collect( Collectors.toSet() ) )
 		{
@@ -102,8 +102,8 @@ public class GlobalOptStitcher
 						{
 							// ugly, but just undoes the casting to
 							// ViewId in constructor
-							BasicViewDescription< ? extends BasicViewSetup > vdA = (BasicViewDescription< ? extends BasicViewSetup >) views.get( i );
-							BasicViewDescription< ? extends BasicViewSetup > vdB = (BasicViewDescription< ? extends BasicViewSetup >) views.get( j );
+							BasicViewDescription< ? > vdA = (BasicViewDescription< ? >) views.get( i );
+							BasicViewDescription< ? > vdB = (BasicViewDescription< ? >) views.get( j );
 
 							if ( cl == TimePoint.class )
 								differInApplicationAxis |= !vdA.getTimePoint().equals( vdB.getTimePoint() );
@@ -112,7 +112,7 @@ public class GlobalOptStitcher
 										.equals( vdB.getViewSetup().getAttribute( cl ) );
 						}
 						if ( !differInApplicationAxis )
-							res.add( new ValuePair< ViewId, ViewId >( views.get( i ), views.get( j ) ) );
+							res.add( new ValuePair<>( views.get( i ), views.get( j ) ) );
 					}
 
 				return res;

--- a/src/main/java/net/preibisch/stitcher/gui/LinkExplorerPanel.java
+++ b/src/main/java/net/preibisch/stitcher/gui/LinkExplorerPanel.java
@@ -64,7 +64,7 @@ import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constell
 import net.preibisch.stitcher.algorithm.FilteredStitchingResults;
 import net.preibisch.stitcher.gui.popup.LinkExplorerRemoveLinkPopup;
 
-public class LinkExplorerPanel extends JPanel implements SelectedViewDescriptionListener< AbstractSpimData<?> >
+public class LinkExplorerPanel extends JPanel implements SelectedViewDescriptionListener< AbstractSpimData< ? > >
 {
 	public static double minCorrDefault = 0.7;
 	public static double maxCorrDefault = 1.0;
@@ -99,7 +99,9 @@ public class LinkExplorerPanel extends JPanel implements SelectedViewDescription
 	}
 
 	private StitchingResults results;
-	private StitchingExplorerPanel< AbstractSpimData< ? >, ? > parent;
+
+	private StitchingExplorerPanel< AbstractSpimData< ? > > parent;
+
 	LinkExplorerTableModel model;
 	protected JTable table;
 	private List<Pair<Group<ViewId>, Group<ViewId>>> activeLinks;
@@ -115,7 +117,7 @@ public class LinkExplorerPanel extends JPanel implements SelectedViewDescription
 		model.fireTableDataChanged();
 	}
 
-	public LinkExplorerPanel (StitchingResults results, StitchingExplorerPanel< AbstractSpimData< ? >, ? > parent)
+	public LinkExplorerPanel( StitchingResults results, StitchingExplorerPanel< AbstractSpimData< ? > > parent )
 	{
 		this.results = results;
 		this.parent = parent;
@@ -374,8 +376,7 @@ public class LinkExplorerPanel extends JPanel implements SelectedViewDescription
 
 
 	@Override
-	public void selectedViewDescriptions(
-			List< List< BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions)
+	public void selectedViewDescriptions( List< List< BasicViewDescription< ? > > > viewDescriptions )
 	{
 		if (viewDescriptions.size() < 1) // nothing selected
 		{

--- a/src/main/java/net/preibisch/stitcher/gui/PreviewRegularGridPanel.java
+++ b/src/main/java/net/preibisch/stitcher/gui/PreviewRegularGridPanel.java
@@ -80,7 +80,7 @@ public class PreviewRegularGridPanel <AS extends AbstractSpimData<?> > extends J
 	public static int[] dimensionOrderOld = null;
 	public static Boolean keepMetadataRotationOld = true;
 
-	private ExplorerWindow< AS, ?> parent;
+	private ExplorerWindow< AS > parent;
 
 	// UI elements
 	private List<JCheckBox> alternatingCheckboxes;
@@ -111,7 +111,7 @@ public class PreviewRegularGridPanel <AS extends AbstractSpimData<?> > extends J
 
 	private final static String[] dimensionNames = new String[] {"X", "Y", "Z"};
 
-	public PreviewRegularGridPanel(ExplorerWindow< AS, ? > parent)
+	public PreviewRegularGridPanel(ExplorerWindow< AS > parent)
 	{
 		int iconSizeX = 80;
 		int iconSizeY = 80;
@@ -306,7 +306,7 @@ public class PreviewRegularGridPanel <AS extends AbstractSpimData<?> > extends J
 
 		// add this as a listener for selection changes in parent view explorer
 		// this should trigger update immediately
-		FilteredAndGroupedExplorerPanel< AS,? > FilteredAndGroupedExplorerPanel = (FilteredAndGroupedExplorerPanel< AS,? >)parent;
+		FilteredAndGroupedExplorerPanel< AS > FilteredAndGroupedExplorerPanel = (FilteredAndGroupedExplorerPanel< AS >)parent;
 		FilteredAndGroupedExplorerPanel.addListener( this );
 		
 		if (oldOverlap == null)
@@ -528,7 +528,7 @@ public class PreviewRegularGridPanel <AS extends AbstractSpimData<?> > extends J
 
 	public void quit()
 	{
-		FilteredAndGroupedExplorerPanel< AS,? > panel = (FilteredAndGroupedExplorerPanel< AS,? >)parent;
+		FilteredAndGroupedExplorerPanel< AS > panel = (FilteredAndGroupedExplorerPanel< AS >)parent;
 		panel.getListeners().remove( this );
 		
 		final BigDataViewer bdv = parent.bdvPopup().getBDV();		
@@ -548,8 +548,7 @@ public class PreviewRegularGridPanel <AS extends AbstractSpimData<?> > extends J
 	}
 
 	@Override
-	public void selectedViewDescriptions(
-			List< List< BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions)
+	public void selectedViewDescriptions( List< List< BasicViewDescription< ? > > > viewDescriptions )
 	{
 		//System.out.println( " selection upd " );
 		selectedVDs = viewDescriptions;

--- a/src/main/java/net/preibisch/stitcher/gui/StitchingExplorer.java
+++ b/src/main/java/net/preibisch/stitcher/gui/StitchingExplorer.java
@@ -64,12 +64,12 @@ import mpicbg.spim.data.XmlIoSpimData;
 import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.XmlIoAbstractSpimData;
 
-public class StitchingExplorer< AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS > > extends FilteredAndGroupedExplorer< AS, X >
+public class StitchingExplorer< AS extends AbstractSpimData< ? > > extends FilteredAndGroupedExplorer< AS >
 {
 
 	private AS data;
 	private String xml;
-	private X io;
+	private XmlIoAbstractSpimData< ?, AS > io;
 	private Mode currentMode;
 
 	private JButton bStitching, bMV;
@@ -78,9 +78,9 @@ public class StitchingExplorer< AS extends AbstractSpimData< ? >, X extends XmlI
 		STITCHING,
 		MULTIVIEW
 	}
-	
-	
-	public StitchingExplorer( final AS data, final String xml, final X io )
+
+
+	public StitchingExplorer( final AS data, final String xml, final XmlIoAbstractSpimData< ?, AS > io )
 	{
 		this.data = data;
 		this.xml = xml;
@@ -111,7 +111,7 @@ public class StitchingExplorer< AS extends AbstractSpimData< ? >, X extends XmlI
 
 		header.add( buttons, BorderLayout.WEST );
 
-		panel = new StitchingExplorerPanel< AS, X >( this, data, xml, io , true);
+		panel = new StitchingExplorerPanel< AS >( this, data, xml, io , true);
 
 		frame.add( header, BorderLayout.NORTH );
 		frame.add( panel, BorderLayout.CENTER );
@@ -179,9 +179,9 @@ public class StitchingExplorer< AS extends AbstractSpimData< ? >, X extends XmlI
 			
 			if (mode == Mode.MULTIVIEW)
 			{
-				bdvExisting.getViewer().removeTransformListener( ((StitchingExplorerPanel< AS, X >) panel).linkOverlay );
-				bdvExisting.getViewer().getDisplay().removeOverlayRenderer( ((StitchingExplorerPanel< AS, X >) panel).linkOverlay );
-				((StitchingExplorerPanel< AS, X >) panel).quitLinkExplorer();
+				bdvExisting.getViewer().removeTransformListener( ((StitchingExplorerPanel< AS >) panel).linkOverlay );
+				bdvExisting.getViewer().getDisplay().removeOverlayRenderer( ((StitchingExplorerPanel< AS >) panel).linkOverlay );
+				((StitchingExplorerPanel< AS >) panel).quitLinkExplorer();
 				FilteredAndGroupedExplorerPanel.resetBDVManualTransformations( bdvExisting );
 			}
 //			new Thread( () -> {panel.bdvPopup().closeBDV();} ).start();			
@@ -199,7 +199,7 @@ public class StitchingExplorer< AS extends AbstractSpimData< ? >, X extends XmlI
 		data = panel.getSpimData();
 		
 		// make new panel
-		panel = mode == Mode.STITCHING ? new StitchingExplorerPanel<AS, X>(  this, data, xml, io , false) : new ViewSetupExplorerPanel<AS, X>(  this, data, xml, io , false );
+		panel = mode == Mode.STITCHING ? new StitchingExplorerPanel<>(  this, data, xml, io , false) : new ViewSetupExplorerPanel<>(  this, data, xml, io , false );
 		frame.add( panel, BorderLayout.CENTER );
 		frame.setSize( panel.getPreferredSize() );
 		frame.pack();
@@ -254,6 +254,6 @@ public class StitchingExplorer< AS extends AbstractSpimData< ? >, X extends XmlI
 	{
 		new ImageJ();
 		//new ViewSetupExplorer<>( GenerateSpimData.grid3x2(), null, null );
-		new StitchingExplorer< SpimData2, XmlIoSpimData2 >( SpimData2.convert( GenerateSpimData.grid3x2()), null, null );
+		new StitchingExplorer<>( SpimData2.convert( GenerateSpimData.grid3x2()), null, null );
 	}
 }

--- a/src/main/java/net/preibisch/stitcher/gui/StitchingExplorerPanel.java
+++ b/src/main/java/net/preibisch/stitcher/gui/StitchingExplorerPanel.java
@@ -142,8 +142,8 @@ import net.preibisch.stitcher.gui.popup.TranslateGroupManuallyPopup;
 import net.preibisch.stitcher.gui.popup.VerifyLinksPopup;
 import net.preibisch.stitcher.input.FractalImgLoader;
 
-public class StitchingExplorerPanel<AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS >>
-		extends FilteredAndGroupedExplorerPanel< AS, X > implements ExplorerWindow< AS, X >
+public class StitchingExplorerPanel<AS extends AbstractSpimData< ? > >
+		extends FilteredAndGroupedExplorerPanel< AS > implements ExplorerWindow< AS >
 {
 	public final static double xPosLinkExplorer = 0.6;
 	public final static double yPosLinkExplorer = 0.0;
@@ -172,8 +172,8 @@ public class StitchingExplorerPanel<AS extends AbstractSpimData< ? >, X extends 
 	protected JCheckBox checkboxGroupChannels;
 	protected JCheckBox checkboxGroupIllums;
 
-	public StitchingExplorerPanel(final FilteredAndGroupedExplorer< AS, X > explorer, final AS data, final String xml,
-			final X io, boolean requestStartBDV)
+	public StitchingExplorerPanel(final FilteredAndGroupedExplorer< AS > explorer, final AS data, final String xml,
+			final XmlIoAbstractSpimData< ?, AS > io, boolean requestStartBDV)
 	{
 		super( explorer, data, xml, io );
 
@@ -717,11 +717,10 @@ public class StitchingExplorerPanel<AS extends AbstractSpimData< ? >, X extends 
 								break;
 							}
 
-					// FIXME: some generics fixes necessary to avoid this ugly cast (which is necessary for maven to compile)
-					selectedRows.add( (List<BasicViewDescription< ? extends BasicViewSetup >>) (Object) tableModel.getElements().get( row ) );
+					selectedRows.add( tableModel.getElements().get( row ) );
 				}
 
-				final List< List< BasicViewDescription< ? extends BasicViewSetup > > > selectedList = new ArrayList< >( selectedRows );
+				final List< List< BasicViewDescription< ? > > > selectedList = new ArrayList<>( selectedRows );
 				/*for ( List< BasicViewDescription< ? extends BasicViewSetup > > selectedI : selectedRows )
 					selectedList.add( selectedI );*/
 
@@ -767,7 +766,7 @@ public class StitchingExplorerPanel<AS extends AbstractSpimData< ? >, X extends 
 		if ( linkExplorer != null )
 			return;
 
-		linkExplorer = new LinkExplorerPanel( stitchingResults, (StitchingExplorerPanel< AbstractSpimData< ? >, ? >) this );
+		linkExplorer = new LinkExplorerPanel( stitchingResults, (StitchingExplorerPanel< AbstractSpimData< ? > >) this );
 		// init the LinkExplorer
 		linkFrame = new JFrame( "Link Explorer" );
 		linkFrame.add( linkExplorer, BorderLayout.CENTER );
@@ -892,8 +891,8 @@ public class StitchingExplorerPanel<AS extends AbstractSpimData< ? >, X extends 
 			return;
 
 		// in Preview Mode, only one row should be selected
-		List< BasicViewDescription< ? extends BasicViewSetup > > selectedRow = selectedRowsGroups().iterator().next();
-		BasicViewDescription< ? extends BasicViewSetup > firstVD = firstSelectedVD;
+		List< BasicViewDescription< ? > > selectedRow = selectedRowsGroups().iterator().next();
+		BasicViewDescription< ? > firstVD = firstSelectedVD;
 
 		if ( selectedRow == null || selectedRow.size() == 0 )
 			return;

--- a/src/main/java/net/preibisch/stitcher/gui/StitchingExplorerPanel.java
+++ b/src/main/java/net/preibisch/stitcher/gui/StitchingExplorerPanel.java
@@ -930,7 +930,7 @@ public class StitchingExplorerPanel<AS extends AbstractSpimData< ? > >
 		final boolean[] active = new boolean[data.getSequenceDescription().getViewSetupsOrdered().size()];
 
 		// set all views of the selected row visible
-		for ( final BasicViewDescription< ? extends BasicViewSetup > vd : selectedRow )
+		for ( final BasicViewDescription< ? > vd : selectedRow )
 			if ( vd.getTimePointId() == firstTP.getId() )
 				active[getBDVSourceIndex( vd.getViewSetup(), data )] = true;
 

--- a/src/main/java/net/preibisch/stitcher/gui/StitchingTableModelDecorator.java
+++ b/src/main/java/net/preibisch/stitcher/gui/StitchingTableModelDecorator.java
@@ -223,7 +223,7 @@ public class StitchingTableModelDecorator < AS extends AbstractSpimData< ? > > e
 	}
 
 	@Override
-	public ExplorerWindow<AS, ?> getPanel() { return decorated.getPanel(); }
+	public ExplorerWindow<AS> getPanel() { return decorated.getPanel(); }
 
 	@Override
 	public void setStitchingResults(StitchingResults res)

--- a/src/main/java/net/preibisch/stitcher/gui/TranslateGroupManuallyPanel.java
+++ b/src/main/java/net/preibisch/stitcher/gui/TranslateGroupManuallyPanel.java
@@ -332,7 +332,7 @@ public class TranslateGroupManuallyPanel extends JPanel implements SelectedViewD
 	}
 	
 	@Override
-	public void selectedViewDescriptions(List< List< BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions)
+	public void selectedViewDescriptions(List< List< BasicViewDescription< ? > > > viewDescriptions)
 	{
 		// @pietzscht
 		// the entire code here has nothing to do with changing colors (I uncommented everything and it still changes colors)

--- a/src/main/java/net/preibisch/stitcher/gui/bdv/BDVVisibilityHandlerNeighborhood.java
+++ b/src/main/java/net/preibisch/stitcher/gui/bdv/BDVVisibilityHandlerNeighborhood.java
@@ -48,10 +48,10 @@ import net.preibisch.stitcher.gui.popup.BDVPopupStitching;
 
 public class BDVVisibilityHandlerNeighborhood implements BDVVisibilityHandler
 {
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 	private long colorOffset;
 
-	public BDVVisibilityHandlerNeighborhood( ExplorerWindow< ?, ? > panel, long colorOffset )
+	public BDVVisibilityHandlerNeighborhood( ExplorerWindow< ? > panel, long colorOffset )
 	{
 		this.panel = panel;
 		this.colorOffset = colorOffset;
@@ -107,7 +107,7 @@ public class BDVVisibilityHandlerNeighborhood implements BDVVisibilityHandler
 		{
 			// get all filters from model
 			final ISpimDataTableModel< ? > tableModel =
-					((FilteredAndGroupedExplorerPanel< ?, ? >)panel).getTableModel();
+					( ( FilteredAndGroupedExplorerPanel< ? > ) panel ).getTableModel();
 			final Map< Class< ? extends Entity >, List< ? extends Entity > > filters = tableModel.getFilters();
 
 			// check all candidates

--- a/src/main/java/net/preibisch/stitcher/gui/bdv/BDVVisibilityHandlerNeighborhood.java
+++ b/src/main/java/net/preibisch/stitcher/gui/bdv/BDVVisibilityHandlerNeighborhood.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 
 import bdv.BigDataViewer;
 import bdv.tools.brightness.ConverterSetup;
-import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.base.Entity;
 import mpicbg.spim.data.sequence.TimePoint;
 import mpicbg.spim.data.sequence.ViewId;
@@ -49,10 +48,10 @@ import net.preibisch.stitcher.gui.popup.BDVPopupStitching;
 
 public class BDVVisibilityHandlerNeighborhood implements BDVVisibilityHandler
 {
-	private ExplorerWindow< ? extends AbstractSpimData< ? >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 	private long colorOffset;
 
-	public BDVVisibilityHandlerNeighborhood(ExplorerWindow< ? extends AbstractSpimData< ? >, ? > panel, long colorOffset)
+	public BDVVisibilityHandlerNeighborhood( ExplorerWindow< ?, ? > panel, long colorOffset )
 	{
 		this.panel = panel;
 		this.colorOffset = colorOffset;
@@ -107,8 +106,8 @@ public class BDVVisibilityHandlerNeighborhood implements BDVVisibilityHandler
 		if (FilteredAndGroupedExplorerPanel.class.isInstance( panel ))
 		{
 			// get all filters from model
-			final ISpimDataTableModel< ? extends AbstractSpimData< ? > > tableModel =
-					((FilteredAndGroupedExplorerPanel< ? extends AbstractSpimData< ? >, ? >)panel).getTableModel();
+			final ISpimDataTableModel< ? > tableModel =
+					((FilteredAndGroupedExplorerPanel< ?, ? >)panel).getTableModel();
 			final Map< Class< ? extends Entity >, List< ? extends Entity > > filters = tableModel.getFilters();
 
 			// check all candidates

--- a/src/main/java/net/preibisch/stitcher/gui/overlay/DemoLinkOverlay.java
+++ b/src/main/java/net/preibisch/stitcher/gui/overlay/DemoLinkOverlay.java
@@ -261,8 +261,7 @@ public class DemoLinkOverlay implements OverlayRenderer, TransformListener< Affi
 
 
 	@Override
-	public void selectedViewDescriptions(
-			List< List< BasicViewDescription< ? extends BasicViewSetup > > > viewDescriptions)
+	public void selectedViewDescriptions( List< List< BasicViewDescription< ? > > > viewDescriptions )
 	{
 		List<Pair<Group<ViewId>, Group<ViewId>>> res = new ArrayList<>();
 		for (int i = 0; i<viewDescriptions.size(); i++)

--- a/src/main/java/net/preibisch/stitcher/gui/popup/ApplyBDVTransformationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/ApplyBDVTransformationPopup.java
@@ -47,7 +47,7 @@ public class ApplyBDVTransformationPopup extends JMenuItem implements ExplorerWi
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public ApplyBDVTransformationPopup()
 	{
@@ -56,7 +56,7 @@ public class ApplyBDVTransformationPopup extends JMenuItem implements ExplorerWi
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/ApplyBDVTransformationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/ApplyBDVTransformationPopup.java
@@ -27,8 +27,6 @@ import javax.swing.JMenuItem;
 import bdv.BigDataViewer;
 import bdv.tools.transformation.TransformedSource;
 import bdv.viewer.state.SourceState;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.registration.ViewRegistration;
 import mpicbg.spim.data.registration.ViewTransform;
 import mpicbg.spim.data.registration.ViewTransformAffine;
@@ -44,16 +42,16 @@ public class ApplyBDVTransformationPopup extends JMenuItem implements ExplorerWi
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
-	public ApplyBDVTransformationPopup() 
+	public ApplyBDVTransformationPopup()
 	{
 		super( "Apply BDV Transformation to Data" );
 		this.addActionListener( new MyActionListener() );
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/ApplyBDVTransformationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/ApplyBDVTransformationPopup.java
@@ -21,16 +21,21 @@
  */
 package net.preibisch.stitcher.gui.popup;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import javax.swing.JMenuItem;
+import bdv.AbstractSpimSource;
 import bdv.BigDataViewer;
 import bdv.tools.transformation.TransformedSource;
-import bdv.viewer.state.SourceState;
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.ViewerState;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import javax.swing.JMenuItem;
 import mpicbg.spim.data.registration.ViewRegistration;
+import mpicbg.spim.data.registration.ViewRegistrations;
 import mpicbg.spim.data.registration.ViewTransform;
 import mpicbg.spim.data.registration.ViewTransformAffine;
-import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.TimePoint;
 import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.preibisch.legacy.io.IOFunctions;
@@ -38,7 +43,7 @@ import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
 
 public class ApplyBDVTransformationPopup extends JMenuItem implements ExplorerWindowSetable {
-	
+
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
@@ -69,45 +74,81 @@ public class ApplyBDVTransformationPopup extends JMenuItem implements ExplorerWi
 			}
 
 			BigDataViewer bdv = panel.bdvPopup().getBDV();
-			
+
 			if (bdv == null)
 			{
 				IOFunctions.println( "BigDataViewer is not open. Please start it to access this functionality." );
 				return;
-			}			
-			
-			
-			for (int i = 0; i < bdv.getViewer().getVisibilityAndGrouping().numSources(); ++i)
-			{
-				Integer tpId = bdv.getViewer().getState().getCurrentTimepoint();
-				SourceState<?> s = bdv.getViewer().getVisibilityAndGrouping().getSources().get( i );
-				
-				// get manual transform
-				AffineTransform3D tAffine = new AffineTransform3D();
-				((TransformedSource< ? >)s.getSpimSource()).getFixedTransform( tAffine );
-				
-				// get old transform
-				ViewRegistration vr = panel.getSpimData().getViewRegistrations().getViewRegistration( new ViewId(tpId, i ));
-				AffineGet old = vr.getTransformList().get( 1 ).asAffine3D();
-				
-				// update transform in ViewRegistrations
-				AffineTransform3D newTransform = new AffineTransform3D();
-				newTransform.set( old.get( 0, 3 ) + tAffine.get( 0, 3 ), 0, 3 );
-				newTransform.set( old.get( 1, 3 ) + tAffine.get( 1, 3 ), 1, 3 );
-				newTransform.set( old.get( 2, 3 ) + tAffine.get( 2, 3 ), 2, 3 );
-				
-				ViewTransform newVt = new ViewTransformAffine( "Translation", newTransform );				
-				vr.getTransformList().set( 1, newVt );
-				vr.updateModel();
-				
-				// reset manual transform
-				((TransformedSource< ? >)s.getSpimSource()).setFixedTransform( new AffineTransform3D() );
-				bdv.getViewer().requestRepaint();
 			}
-			
-			panel.bdvPopup().updateBDV();			
-			
+
+			final ViewerState state = bdv.getViewer().state().snapshot();
+
+			final List< TimePoint > timePointsOrdered = panel.getSpimData().getSequenceDescription().getTimePoints().getTimePointsOrdered();
+			final int tpId = timePointsOrdered.get( state.getCurrentTimepoint() ).getId();
+
+			final ViewRegistrations viewRegistrations = panel.getSpimData().getViewRegistrations();
+
+			for ( SourceAndConverter< ? > source : state.getSources() )
+			{
+				try
+				{
+					applyManualTransform( source, viewRegistrations, tpId );
+				}
+				catch ( IllegalArgumentException exception )
+				{
+					// source is not AbstractSpimSource wrapped a TransformedSource.
+					// ==> Just ignore this source.
+				}
+			}
+
+			panel.bdvPopup().updateBDV();
 		}
 	}
 
+	/**
+	 * Apply manual transform permanently, by adding it to {@link ViewRegistration}.
+	 * <p>
+	 * This method assume that {@code source} is a {@link TransformedSource}
+	 * that wraps an {@link AbstractSpimSource}.
+	 *
+	 * @param source source for which to apply the manual transform
+	 * @param viewRegistrations containing the {@code ViewRegistration} for source
+	 * @param timepointId id of the timepoint where transformations should be applied
+	 *
+	 * @throws IllegalArgumentException id {@code source} is not a {@link TransformedSource} that wraps an {@link AbstractSpimSource}.
+	 */
+	// TODO (TP): shouldn't the transformation be applied to all timepoints?
+	private static void applyManualTransform( final SourceAndConverter< ? > source, final ViewRegistrations viewRegistrations, final int timepointId ) throws IllegalArgumentException
+	{
+		if ( !( source.getSpimSource() instanceof TransformedSource ) )
+			throw new IllegalArgumentException( "expected TransformedSource, not " + source.getSpimSource() );
+		final TransformedSource< ? > tfs = ( TransformedSource< ? > ) source.getSpimSource();
+
+		if ( !( tfs.getWrappedSource() instanceof AbstractSpimSource ) )
+			throw new IllegalArgumentException( "expected AbstractSpimSource, got " + tfs.getWrappedSource() );
+		final AbstractSpimSource< ? > s = ( AbstractSpimSource< ? > ) tfs.getWrappedSource();
+
+		// TODO (TP): The following makes some very specific assumptions of the TransformList. It looks extremely fragile. What was the intended purpose?
+
+		// get manual transform
+		AffineTransform3D tAffine = new AffineTransform3D();
+		tfs.getFixedTransform( tAffine );
+
+		// get old transform
+		ViewRegistration vr = viewRegistrations.getViewRegistration( timepointId, s.getSetupId() );
+		AffineGet old = vr.getTransformList().get( 1 ).asAffine3D();
+
+		// update transform in ViewRegistrations
+		AffineTransform3D newTransform = new AffineTransform3D();
+		newTransform.set( old.get( 0, 3 ) + tAffine.get( 0, 3 ), 0, 3 );
+		newTransform.set( old.get( 1, 3 ) + tAffine.get( 1, 3 ), 1, 3 );
+		newTransform.set( old.get( 2, 3 ) + tAffine.get( 2, 3 ), 2, 3 );
+
+		ViewTransform newVt = new ViewTransformAffine( "Translation", newTransform );
+		vr.getTransformList().set( 1, newVt );
+		vr.updateModel();
+
+		// reset manual transform
+		tfs.setFixedTransform( new AffineTransform3D() );
+	}
 }

--- a/src/main/java/net/preibisch/stitcher/gui/popup/BDVPopupStitching.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/BDVPopupStitching.java
@@ -268,7 +268,7 @@ public class BDVPopupStitching extends BDVPopup
 		ScrollableBrightnessDialog.updateBrightnessPanels( bdv );
 	}
 
-	public static BigDataViewer createBDV( final ExplorerWindow< ? , ? > panel , LinkOverlay lo)
+	public static BigDataViewer createBDV( final ExplorerWindow< ? > panel , LinkOverlay lo)
 	{
 		if ( AbstractImgLoader.class.isInstance( panel.getSpimData().getSequenceDescription().getImgLoader() ) )
 		{

--- a/src/main/java/net/preibisch/stitcher/gui/popup/BDVPopupStitching.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/BDVPopupStitching.java
@@ -303,10 +303,9 @@ public class BDVPopupStitching extends BDVPopup
 												null, 
 												options );
 
-		BDVPopup.initTransform( bdv.getViewer() );		
-		// if ( !bdv.tryLoadSettings( panel.xml() ) ) TODO: this should
-		// work, but currently tryLoadSettings is protected. fix that.
-		BDVPopup.initBrightness( 0.001, 0.999, bdv.getViewer().getState(), bdv.getSetupAssignments() );
+		BDVPopup.initTransform( bdv.getViewer() );
+		if ( !bdv.tryLoadSettings( panel.xml() ) )
+			BDVPopup.initBrightness( 0.001, 0.999, bdv.getViewerFrame() );
 
 		FilteredAndGroupedExplorerPanel.setFusedModeSimple( bdv, panel.getSpimData() );
 

--- a/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopup.java
@@ -61,7 +61,7 @@ public class CalculatePCPopup extends JMenuItem implements ExplorerWindowSetable
 		LUCASKANADE
 	}
 
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 	private boolean simple;
 	private boolean wizardMode;
 	private Method method;
@@ -76,7 +76,7 @@ public class CalculatePCPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;
@@ -114,8 +114,8 @@ public class CalculatePCPopup extends JMenuItem implements ExplorerWindowSetable
 					final boolean expertGrouping = method == Method.PHASECORRELATION ? params.showExpertGrouping : LKParams.showExpertGrouping;
 
 					@SuppressWarnings("unchecked")
-					FilteredAndGroupedExplorerPanel< SpimData2, ? > panelFG = (FilteredAndGroupedExplorerPanel< SpimData2, ? >) panel;
-					SpimDataFilteringAndGrouping< SpimData2 > filteringAndGrouping = 	new SpimDataFilteringAndGrouping< SpimData2 >( (SpimData2) panel.getSpimData() );
+					FilteredAndGroupedExplorerPanel< SpimData2 > panelFG = (FilteredAndGroupedExplorerPanel< SpimData2 >) panel;
+					SpimDataFilteringAndGrouping< SpimData2 > filteringAndGrouping = 	new SpimDataFilteringAndGrouping<>( (SpimData2) panel.getSpimData() );
 
 					if (simple || !expertGrouping)
 					{
@@ -189,8 +189,8 @@ public class CalculatePCPopup extends JMenuItem implements ExplorerWindowSetable
 							final int choice = JOptionPane.showConfirmDialog( (Component) panel, "Pairwise shift calculation done. Switch to preview mode?", "Preview Mode", JOptionPane.YES_NO_OPTION );
 							if (choice == JOptionPane.YES_OPTION)
 							{
-								((StitchingExplorerPanel< ?, ? >) panel).setSavedFilteringAndGrouping( filteringAndGrouping );
-								((StitchingExplorerPanel< ?, ? >) panel).togglePreviewMode(false);
+								((StitchingExplorerPanel< ? >) panel).setSavedFilteringAndGrouping( filteringAndGrouping );
+								((StitchingExplorerPanel< ? >) panel).togglePreviewMode(false);
 							}
 						}
 					}

--- a/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopup.java
@@ -32,9 +32,7 @@ import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.base.Entity;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.Illumination;
 import mpicbg.spim.data.sequence.Tile;
@@ -43,13 +41,11 @@ import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.FilteredAndGroupedExplorerPanel;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
-import net.preibisch.mvrecon.fiji.spimdata.stitchingresults.StitchingResults;
 import net.preibisch.stitcher.algorithm.PairwiseStitchingParameters;
 import net.preibisch.stitcher.algorithm.SpimDataFilteringAndGrouping;
 import net.preibisch.stitcher.algorithm.GroupedViewAggregator.ActionType;
 import net.preibisch.stitcher.algorithm.lucaskanade.LucasKanadeParameters;
 import net.preibisch.stitcher.gui.StitchingExplorerPanel;
-import net.preibisch.stitcher.gui.StitchingResultsSettable;
 import net.preibisch.stitcher.gui.StitchingUIHelper;
 import net.preibisch.stitcher.plugin.Calculate_Pairwise_Shifts;
 
@@ -65,7 +61,7 @@ public class CalculatePCPopup extends JMenuItem implements ExplorerWindowSetable
 		LUCASKANADE
 	}
 
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 	private boolean simple;
 	private boolean wizardMode;
 	private Method method;
@@ -80,8 +76,7 @@ public class CalculatePCPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopupExpertBatch.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopupExpertBatch.java
@@ -24,12 +24,8 @@ package net.preibisch.stitcher.gui.popup;
 import javax.swing.JComponent;
 import javax.swing.JMenu;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
-import net.preibisch.mvrecon.fiji.spimdata.stitchingresults.StitchingResults;
-import net.preibisch.stitcher.gui.StitchingResultsSettable;
 import net.preibisch.stitcher.gui.popup.CalculatePCPopup.Method;
 
 public class CalculatePCPopupExpertBatch extends JMenu implements ExplorerWindowSetable
@@ -64,10 +60,9 @@ public class CalculatePCPopupExpertBatch extends JMenu implements ExplorerWindow
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
-		if (!wizardMode)
+		if ( !wizardMode )
 			this.phaseCorrSimple.setExplorerWindow( panel );
 		this.phaseCorr.setExplorerWindow( panel );
 		this.lucasKanade.setExplorerWindow( panel );

--- a/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopupExpertBatch.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/CalculatePCPopupExpertBatch.java
@@ -60,7 +60,7 @@ public class CalculatePCPopupExpertBatch extends JMenu implements ExplorerWindow
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		if ( !wizardMode )
 			this.phaseCorrSimple.setExplorerWindow( panel );

--- a/src/main/java/net/preibisch/stitcher/gui/popup/DemoLinkOverlayPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/DemoLinkOverlayPopup.java
@@ -42,7 +42,7 @@ public class DemoLinkOverlayPopup extends JMenuItem implements ExplorerWindowSet
 {
 	private static final long serialVersionUID = 1L;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 	DemoLinkOverlay overlay;
 	boolean active = false;
 	MyActionListener actionListener;
@@ -57,7 +57,7 @@ public class DemoLinkOverlayPopup extends JMenuItem implements ExplorerWindowSet
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/DemoLinkOverlayPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/DemoLinkOverlayPopup.java
@@ -31,8 +31,6 @@ import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 
 import bdv.BigDataViewer;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.imglib2.type.numeric.ARGBType;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
@@ -44,7 +42,7 @@ public class DemoLinkOverlayPopup extends JMenuItem implements ExplorerWindowSet
 {
 	private static final long serialVersionUID = 1L;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 	DemoLinkOverlay overlay;
 	boolean active = false;
 	MyActionListener actionListener;
@@ -59,8 +57,7 @@ public class DemoLinkOverlayPopup extends JMenuItem implements ExplorerWindowSet
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/DisplayOverlapTestPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/DisplayOverlapTestPopup.java
@@ -35,11 +35,8 @@ import javax.swing.JMenuItem;
 
 import ij.gui.GenericDialog;
 import mpicbg.spim.data.SpimData;
-import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.BasicImgLoader;
-import mpicbg.spim.data.generic.sequence.BasicViewDescription;
-import mpicbg.spim.data.generic.sequence.BasicViewSetup;
 import mpicbg.spim.data.registration.ViewRegistration;
 import mpicbg.spim.data.registration.ViewRegistrations;
 import mpicbg.spim.data.sequence.Channel;
@@ -72,12 +69,11 @@ import net.preibisch.stitcher.algorithm.GroupedViewAggregator.ActionType;
 
 public class DisplayOverlapTestPopup extends JMenuItem implements ExplorerWindowSetable {
 
-	
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
-	
+
+	ExplorerWindow< ?, ? > panel;
+
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;
@@ -177,8 +173,8 @@ public class DisplayOverlapTestPopup extends JMenuItem implements ExplorerWindow
 		return res;
 	}
 
-	
-	public static <S extends AbstractSequenceDescription< ?,? extends BasicViewDescription<? extends BasicViewSetup>, ?  >>
+
+	public static < S extends AbstractSequenceDescription< ?, ?, ? > >
 		List<RandomAccessibleInterval< FloatType >> openVirtuallyFused(
 				S sd,
 				ViewRegistrations vrs,

--- a/src/main/java/net/preibisch/stitcher/gui/popup/DisplayOverlapTestPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/DisplayOverlapTestPopup.java
@@ -70,10 +70,10 @@ import net.preibisch.stitcher.algorithm.GroupedViewAggregator.ActionType;
 public class DisplayOverlapTestPopup extends JMenuItem implements ExplorerWindowSetable {
 
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/FlipAxesPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/FlipAxesPopup.java
@@ -42,7 +42,7 @@ import net.preibisch.stitcher.arrangement.FlipAxes;
 
 public class FlipAxesPopup extends JMenuItem implements ExplorerWindowSetable {
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public FlipAxesPopup()
 	{
@@ -51,7 +51,7 @@ public class FlipAxesPopup extends JMenuItem implements ExplorerWindowSetable {
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/FlipAxesPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/FlipAxesPopup.java
@@ -33,8 +33,6 @@ import javax.swing.JMenuItem;
 
 import ij.gui.GenericDialog;
 import mpicbg.spim.data.SpimData;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.Dimensions;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
@@ -44,7 +42,7 @@ import net.preibisch.stitcher.arrangement.FlipAxes;
 
 public class FlipAxesPopup extends JMenuItem implements ExplorerWindowSetable {
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	public FlipAxesPopup()
 	{
@@ -53,8 +51,7 @@ public class FlipAxesPopup extends JMenuItem implements ExplorerWindowSetable {
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/LinkExplorerRemoveLinkPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/LinkExplorerRemoveLinkPopup.java
@@ -43,7 +43,7 @@ public class LinkExplorerRemoveLinkPopup extends JMenuItem implements StitchingR
 {
 	private LinkExplorerPanel panel;
 	private StitchingResults results;
-	private ExplorerWindow< ?, ? > stitchingExplorer;
+	private ExplorerWindow< ? > stitchingExplorer;
 
 	public LinkExplorerRemoveLinkPopup(LinkExplorerPanel panel)
 	{
@@ -60,8 +60,8 @@ public class LinkExplorerRemoveLinkPopup extends JMenuItem implements StitchingR
 			{
 				final Pair< Group<ViewId>, Group<ViewId> > pair = panel.getModel().getActiveLinks().get( panel.getTable().getSelectedRow() );
 				results.removePairwiseResultForPair( pair );
-				((StitchingExplorerPanel< ?, ? >)stitchingExplorer).updateBDVPreviewMode();
-				
+				((StitchingExplorerPanel< ? >)stitchingExplorer).updateBDVPreviewMode();
+
 				panel.selectedViewDescriptions( new ArrayList<>(((GroupedRowWindow)stitchingExplorer).selectedRowsGroups()) );
 				panel.getModel().fireTableDataChanged();
 			}
@@ -75,7 +75,7 @@ public class LinkExplorerRemoveLinkPopup extends JMenuItem implements StitchingR
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.stitchingExplorer = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/LinkExplorerRemoveLinkPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/LinkExplorerRemoveLinkPopup.java
@@ -24,16 +24,12 @@ package net.preibisch.stitcher.gui.popup;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Set;
 
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.util.Pair;
-import net.imglib2.util.ValuePair;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.GroupedRowWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
@@ -47,8 +43,8 @@ public class LinkExplorerRemoveLinkPopup extends JMenuItem implements StitchingR
 {
 	private LinkExplorerPanel panel;
 	private StitchingResults results;
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ?> stitchingExplorer;
-	
+	private ExplorerWindow< ?, ? > stitchingExplorer;
+
 	public LinkExplorerRemoveLinkPopup(LinkExplorerPanel panel)
 	{
 		super("Remove Link");
@@ -75,15 +71,14 @@ public class LinkExplorerRemoveLinkPopup extends JMenuItem implements StitchingR
 	@Override
 	public void setStitchingResults(StitchingResults res)
 	{
-		results = res;		
+		results = res;
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.stitchingExplorer = panel;
 		return this;
 	}
-	
+
 }

--- a/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopup.java
@@ -40,10 +40,10 @@ public class OptimizeGloballyPopup extends JMenu implements ExplorerWindowSetabl
 
 	public final OptimizeGloballyPopupExpertBatch simpleOptimize;
 	public final OptimizeGloballyPopupExpertBatch expertOptimize;
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 

--- a/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopup.java
@@ -24,17 +24,11 @@ package net.preibisch.stitcher.gui.popup;
 import javax.swing.JComponent;
 import javax.swing.JMenu;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.registration.ViewRegistration;
 import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
-import net.preibisch.mvrecon.fiji.spimdata.stitchingresults.StitchingResults;
-import net.preibisch.stitcher.gui.StitchingExplorerPanel;
-import net.preibisch.stitcher.gui.StitchingResultsSettable;
-import net.preibisch.stitcher.gui.overlay.DemoLinkOverlay;
 
 public class OptimizeGloballyPopup extends JMenu implements ExplorerWindowSetable
 {
@@ -46,11 +40,10 @@ public class OptimizeGloballyPopup extends JMenu implements ExplorerWindowSetabl
 
 	public final OptimizeGloballyPopupExpertBatch simpleOptimize;
 	public final OptimizeGloballyPopupExpertBatch expertOptimize;
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 

--- a/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopupExpertBatch.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopupExpertBatch.java
@@ -27,8 +27,6 @@ import java.awt.event.ActionListener;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
 import net.preibisch.stitcher.algorithm.globalopt.ExecuteGlobalOpt;
@@ -38,12 +36,11 @@ public class OptimizeGloballyPopupExpertBatch extends JMenuItem
 {
 	private static final long serialVersionUID = 1L;
 
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 	private boolean expertMode;
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopupExpertBatch.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/OptimizeGloballyPopupExpertBatch.java
@@ -36,11 +36,11 @@ public class OptimizeGloballyPopupExpertBatch extends JMenuItem
 {
 	private static final long serialVersionUID = 1L;
 
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 	private boolean expertMode;
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/PairwiseInterestPointRegistrationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/PairwiseInterestPointRegistrationPopup.java
@@ -55,7 +55,7 @@ public class PairwiseInterestPointRegistrationPopup extends JMenu implements Exp
 {
 
 	private static final long serialVersionUID = -396274656320474433L;
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	private JMenuItem withDetection;
 	private JMenuItem withoutDetection;
@@ -117,7 +117,7 @@ public class PairwiseInterestPointRegistrationPopup extends JMenu implements Exp
 	}
 
 	@Override
-	public JComponent setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;
@@ -158,8 +158,8 @@ public class PairwiseInterestPointRegistrationPopup extends JMenu implements Exp
 				// get selected groups, filter missing views, get all present and selected vids
 				final SpimData2 data = (SpimData2) panel.getSpimData();
 				@SuppressWarnings("unchecked")
-				FilteredAndGroupedExplorerPanel< SpimData2, ? > panelFG = (FilteredAndGroupedExplorerPanel< SpimData2, ? >) panel;
-				SpimDataFilteringAndGrouping< SpimData2 > filteringAndGrouping = 	new SpimDataFilteringAndGrouping< SpimData2 >( (SpimData2) panel.getSpimData() );
+				FilteredAndGroupedExplorerPanel< SpimData2 > panelFG = (FilteredAndGroupedExplorerPanel< SpimData2 >) panel;
+				SpimDataFilteringAndGrouping< SpimData2 > filteringAndGrouping = 	new SpimDataFilteringAndGrouping<>( (SpimData2) panel.getSpimData() );
 
 				if (!expertGrouping.isSelected())
 				{
@@ -212,8 +212,8 @@ public class PairwiseInterestPointRegistrationPopup extends JMenu implements Exp
 							final int choice = JOptionPane.showConfirmDialog( (Component) panel, "Pairwise shift calculation done. Switch to preview mode?", "Preview Mode", JOptionPane.YES_NO_OPTION );
 							if (choice == JOptionPane.YES_OPTION)
 							{
-								((StitchingExplorerPanel< ?, ? >) panel).setSavedFilteringAndGrouping( filteringAndGrouping );
-								((StitchingExplorerPanel< ?, ? >) panel).togglePreviewMode(false);
+								((StitchingExplorerPanel< ? >) panel).setSavedFilteringAndGrouping( filteringAndGrouping );
+								((StitchingExplorerPanel< ? >) panel).togglePreviewMode(false);
 							}
 						}
 					}

--- a/src/main/java/net/preibisch/stitcher/gui/popup/PairwiseInterestPointRegistrationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/PairwiseInterestPointRegistrationPopup.java
@@ -22,17 +22,10 @@
 package net.preibisch.stitcher.gui.popup;
 
 import java.awt.Component;
-import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
@@ -42,42 +35,18 @@ import javax.swing.JOptionPane;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 
-import ij.gui.GenericDialog;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
-import mpicbg.spim.data.generic.sequence.BasicViewDescription;
-import mpicbg.spim.data.generic.sequence.BasicViewSetup;
-import mpicbg.spim.data.registration.ViewRegistration;
-import mpicbg.spim.data.registration.ViewTransform;
 import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.Illumination;
 import mpicbg.spim.data.sequence.Tile;
-import mpicbg.spim.data.sequence.TimePoint;
 import mpicbg.spim.data.sequence.ViewId;
-import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.util.Pair;
-import net.imglib2.util.Util;
-import net.imglib2.util.ValuePair;
 import net.preibisch.legacy.io.IOFunctions;
-import net.preibisch.mvrecon.fiji.plugin.Interest_Point_Detection;
-import net.preibisch.mvrecon.fiji.plugin.Interest_Point_Registration;
-import net.preibisch.mvrecon.fiji.plugin.interestpointregistration.TransformationModelGUI;
-import net.preibisch.mvrecon.fiji.plugin.interestpointregistration.parameters.BasicRegistrationParameters;
-import net.preibisch.mvrecon.fiji.plugin.interestpointregistration.parameters.GroupParameters.InterestpointGroupingType;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
-import net.preibisch.mvrecon.fiji.spimdata.boundingbox.BoundingBox;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.FilteredAndGroupedExplorerPanel;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.GroupedRowWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
-import net.preibisch.mvrecon.fiji.spimdata.interestpoints.ViewInterestPointLists;
 import net.preibisch.mvrecon.fiji.spimdata.interestpoints.ViewInterestPoints;
-import net.preibisch.mvrecon.fiji.spimdata.stitchingresults.PairwiseStitchingResult;
-import net.preibisch.mvrecon.process.boundingbox.BoundingBoxMaximalGroupOverlap;
-import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constellation.PairwiseSetup;
-import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constellation.grouping.Group;
 import net.preibisch.stitcher.algorithm.SpimDataFilteringAndGrouping;
-import net.preibisch.stitcher.algorithm.globalopt.TransformationTools;
 import net.preibisch.stitcher.gui.StitchingExplorerPanel;
 import net.preibisch.stitcher.gui.StitchingUIHelper;
 import net.preibisch.stitcher.plugin.Calculate_Pairwise_Shifts;
@@ -148,8 +117,7 @@ public class PairwiseInterestPointRegistrationPopup extends JMenu implements Exp
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JComponent setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/ReadTileConfigurationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/ReadTileConfigurationPopup.java
@@ -31,8 +31,6 @@ import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
@@ -41,11 +39,10 @@ import net.preibisch.stitcher.gui.ReadTileConfigurationPanel;
 public class ReadTileConfigurationPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static final long serialVersionUID = 8420300257587465114L;
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/ReadTileConfigurationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/ReadTileConfigurationPopup.java
@@ -39,10 +39,10 @@ import net.preibisch.stitcher.gui.ReadTileConfigurationPanel;
 public class ReadTileConfigurationPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static final long serialVersionUID = 8420300257587465114L;
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/RefineWithICPPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/RefineWithICPPopup.java
@@ -30,8 +30,6 @@ import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.plugin.interestpointregistration.global.GlobalOptimizationParameters;
 import net.preibisch.mvrecon.fiji.plugin.util.MouseOverPopUpStateChanger;
@@ -53,7 +51,7 @@ public class RefineWithICPPopup extends JMenu implements ExplorerWindowSetable
 	private static final long serialVersionUID = 1L;
 
 	DemoLinkOverlay overlay;
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	int downsamplingChoice = ICPRefinement.defaultDownsamplingChoice;
 	int thresholdChoice = ICPRefinement.defaultThresholdChoice;
@@ -176,7 +174,7 @@ public class RefineWithICPPopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 

--- a/src/main/java/net/preibisch/stitcher/gui/popup/RefineWithICPPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/RefineWithICPPopup.java
@@ -51,7 +51,7 @@ public class RefineWithICPPopup extends JMenu implements ExplorerWindowSetable
 	private static final long serialVersionUID = 1L;
 
 	DemoLinkOverlay overlay;
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	int downsamplingChoice = ICPRefinement.defaultDownsamplingChoice;
 	int thresholdChoice = ICPRefinement.defaultThresholdChoice;
@@ -174,7 +174,7 @@ public class RefineWithICPPopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 
@@ -216,8 +216,8 @@ public class RefineWithICPPopup extends JMenu implements ExplorerWindowSetable
 				// get selected groups, filter missing views, get all present and selected vids
 				final SpimData2 data = (SpimData2) panel.getSpimData();
 				@SuppressWarnings("unchecked")
-				FilteredAndGroupedExplorerPanel< SpimData2, ? > panelFG = (FilteredAndGroupedExplorerPanel< SpimData2, ? >) panel;
-				SpimDataFilteringAndGrouping< SpimData2 > filteringAndGrouping = 	new SpimDataFilteringAndGrouping< SpimData2 >( (SpimData2) panel.getSpimData() );
+				FilteredAndGroupedExplorerPanel< SpimData2 > panelFG = (FilteredAndGroupedExplorerPanel< SpimData2 >) panel;
+				SpimDataFilteringAndGrouping< SpimData2 > filteringAndGrouping = 	new SpimDataFilteringAndGrouping<>( (SpimData2) panel.getSpimData() );
 
 				// use whatever is selected in panel as filters
 				filteringAndGrouping.addFilters( panelFG.selectedRowsGroups().stream().reduce( new ArrayList<>(), (x,y ) -> {x.addAll( y ); return x;}) );

--- a/src/main/java/net/preibisch/stitcher/gui/popup/RegularGridPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/RegularGridPopup.java
@@ -29,22 +29,8 @@ import java.awt.event.WindowEvent;
 
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
-import bdv.BigDataViewer;
-import bdv.tools.transformation.TransformedSource;
-import bdv.viewer.state.SourceState;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.XmlIoAbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
-import mpicbg.spim.data.registration.ViewRegistration;
-import mpicbg.spim.data.registration.ViewTransform;
-import mpicbg.spim.data.registration.ViewTransformAffine;
-import mpicbg.spim.data.sequence.ViewId;
-import net.imglib2.realtransform.AffineGet;
-import net.imglib2.realtransform.AffineTransform3D;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
-import net.preibisch.mvrecon.fiji.spimdata.explorer.FilteredAndGroupedExplorer;
-import net.preibisch.mvrecon.fiji.spimdata.explorer.FilteredAndGroupedExplorerPanel;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
 import net.preibisch.stitcher.gui.PreviewRegularGridPanel;
 
@@ -53,7 +39,7 @@ public class RegularGridPopup extends JMenuItem implements ExplorerWindowSetable
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 	PreviewRegularGridPanel< ? > regularGridPanel;
 
 	public RegularGridPopup() 
@@ -63,7 +49,7 @@ public class RegularGridPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/RegularGridPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/RegularGridPopup.java
@@ -39,7 +39,7 @@ public class RegularGridPopup extends JMenuItem implements ExplorerWindowSetable
 	private static final long serialVersionUID = 5234649267634013390L;
 	public static boolean showWarning = true;
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 	PreviewRegularGridPanel< ? > regularGridPanel;
 
 	public RegularGridPopup() 
@@ -49,7 +49,7 @@ public class RegularGridPopup extends JMenuItem implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( final ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( final ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/ResavePopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/ResavePopup.java
@@ -53,7 +53,7 @@ public class ResavePopup extends JMenu implements ExplorerWindowSetable
 	public static final int askWhenMoreThan = 5;
 	private static final long serialVersionUID = 5234649267634013390L;
 
-	FilteredAndGroupedExplorerPanel< ?, ? > panel;
+	FilteredAndGroupedExplorerPanel< ? > panel;
 
 	protected static String[] types = new String[]{ "As TIFF ...", "As compressed TIFF ...", "As HDF5 ...", "As compressed HDF5 ..." };
 
@@ -78,9 +78,9 @@ public class ResavePopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JMenuItem setExplorerWindow( ExplorerWindow< ? > panel )
 	{
-		this.panel = (FilteredAndGroupedExplorerPanel< ?, ? >)panel;
+		this.panel = (FilteredAndGroupedExplorerPanel< ? >)panel;
 		return this;
 	}
 

--- a/src/main/java/net/preibisch/stitcher/gui/popup/ResavePopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/ResavePopup.java
@@ -31,13 +31,8 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.ViewSetup;
-import net.imglib2.img.array.ArrayImgFactory;
-import net.imglib2.img.cell.CellImgFactory;
-import net.imglib2.type.numeric.real.FloatType;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.ImgLib2Temp.Pair;
 import net.preibisch.mvrecon.fiji.plugin.resave.Generic_Resave_HDF5;
@@ -48,10 +43,7 @@ import net.preibisch.mvrecon.fiji.plugin.resave.Resave_TIFF.Parameters;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.FilteredAndGroupedExplorerPanel;
-import net.preibisch.mvrecon.fiji.spimdata.explorer.ViewSetupExplorerPanel;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.AbstractImgFactoryImgLoader;
-import net.preibisch.mvrecon.fiji.spimdata.imgloaders.MicroManagerImgLoader;
 import bdv.export.ExportMipmapInfo;
 import bdv.export.ProgressWriter;
 
@@ -86,7 +78,7 @@ public class ResavePopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JMenuItem setExplorerWindow(ExplorerWindow<? extends AbstractSpimData<? extends AbstractSequenceDescription<?, ?, ?>>, ?> panel )
+	public JMenuItem setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = (FilteredAndGroupedExplorerPanel< ?, ? >)panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SelectIlluminationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SelectIlluminationPopup.java
@@ -84,8 +84,8 @@ public class SelectIlluminationPopup extends JMenuItem implements ExplorerWindow
 	public static boolean defaultOnlySelection = false;
 	public static boolean defaultVerify = true;
 
-	private FilteredAndGroupedExplorerPanel< ?, ? > panel;
-	
+	private FilteredAndGroupedExplorerPanel< ? > panel;
+
 	public SelectIlluminationPopup()
 	{
 		super( "Select Best Illuminations" );
@@ -93,9 +93,9 @@ public class SelectIlluminationPopup extends JMenuItem implements ExplorerWindow
 	}
 	
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
-		this.panel = ( FilteredAndGroupedExplorerPanel< ?, ? > ) panel;
+		this.panel = ( FilteredAndGroupedExplorerPanel< ? > ) panel;
 		return this;
 	}
 
@@ -157,7 +157,7 @@ public class SelectIlluminationPopup extends JMenuItem implements ExplorerWindow
 					}
 
 					final BigDataViewer bdv = panel.bdvPopup().getBDV();
-					final Collection< List< BasicViewDescription< ? extends BasicViewSetup > > > selected = ((GroupedRowWindow)panel).selectedRowsGroups();
+					final Collection< List< BasicViewDescription< ? > > > selected = ((GroupedRowWindow)panel).selectedRowsGroups();
 
 					SpimData2 filteredSpimData = processIlluminationSelection( 
 							(SpimData) panel.getSpimData(),

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SelectIlluminationPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SelectIlluminationPopup.java
@@ -48,7 +48,6 @@ import fiji.util.gui.GenericDialogPlus;
 import ij.IJ;
 import ij.gui.GenericDialog;
 import mpicbg.spim.data.SpimData;
-import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.BasicViewDescription;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
@@ -94,10 +93,9 @@ public class SelectIlluminationPopup extends JMenuItem implements ExplorerWindow
 	}
 	
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
-		this.panel = (FilteredAndGroupedExplorerPanel< ?, ? >)panel;
+		this.panel = ( FilteredAndGroupedExplorerPanel< ?, ? > ) panel;
 		return this;
 	}
 
@@ -215,8 +213,7 @@ public class SelectIlluminationPopup extends JMenuItem implements ExplorerWindow
 		final boolean previewResults = showPreviewOption ? defaultVerify = gdpParams.getNextBoolean() : false;
 		final ViewSelection< ViewId > viewSelection = getViewSelectionResult( gdpParams, data.getSequenceDescription() );
 
-		final SpimDataFilteringAndGrouping< AbstractSpimData< ? > > grouping =
-				new SpimDataFilteringAndGrouping< AbstractSpimData<?> >(data);
+		final SpimDataFilteringAndGrouping< SpimData > grouping = new SpimDataFilteringAndGrouping<>( data );
 		grouping.addGroupingFactor( Illumination.class );
 
 

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SimpleRemoveLinkPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SimpleRemoveLinkPopup.java
@@ -32,8 +32,6 @@ import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 
 import ij.gui.GenericDialog;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
@@ -54,11 +52,10 @@ public class SimpleRemoveLinkPopup extends JMenuItem implements ExplorerWindowSe
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	ExplorerWindow< ?, ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SimpleRemoveLinkPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SimpleRemoveLinkPopup.java
@@ -52,10 +52,10 @@ public class SimpleRemoveLinkPopup extends JMenuItem implements ExplorerWindowSe
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;
@@ -152,7 +152,7 @@ public class SimpleRemoveLinkPopup extends JMenuItem implements ExplorerWindowSe
 				if (! StitchingExplorerPanel.class.isInstance( panel ) )
 					demoOverlay = null;
 				else
-					demoOverlay = (( StitchingExplorerPanel<?,?> )panel).getDemoLinkOverlay();
+					demoOverlay = ( ( StitchingExplorerPanel< ? > ) panel ).getDemoLinkOverlay();
 
 				SpimData2 data = (SpimData2) panel.getSpimData();
 				List< List< ViewId > > selected = ((GroupedRowWindow)panel).selectedRowsViewIdGroups();

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SimpleSubMenu.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SimpleSubMenu.java
@@ -45,7 +45,7 @@ public class SimpleSubMenu extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		children.forEach( c -> {
 			if (ExplorerWindowSetable.class.isInstance( c ))

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SimpleSubMenu.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SimpleSubMenu.java
@@ -28,8 +28,6 @@ import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
 
@@ -47,8 +45,7 @@ public class SimpleSubMenu extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		children.forEach( c -> {
 			if (ExplorerWindowSetable.class.isInstance( c ))

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SkewImagesPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SkewImagesPopup.java
@@ -33,8 +33,6 @@ import javax.swing.JMenuItem;
 
 import ij.gui.GenericDialog;
 import mpicbg.spim.data.SpimData;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.Dimensions;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
@@ -45,11 +43,10 @@ import net.preibisch.stitcher.arrangement.SkewImages;
 public class SkewImagesPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static String[] axesChoice = new String[] {"X", "Y", "Z"};
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
-	
+	ExplorerWindow< ?, ? > panel;
+
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/SkewImagesPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/SkewImagesPopup.java
@@ -43,10 +43,10 @@ import net.preibisch.stitcher.arrangement.SkewImages;
 public class SkewImagesPopup extends JMenuItem implements ExplorerWindowSetable
 {
 	private static String[] axesChoice = new String[] {"X", "Y", "Z"};
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/TogglePreviewPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/TogglePreviewPopup.java
@@ -35,10 +35,10 @@ import net.preibisch.stitcher.gui.StitchingExplorerPanel;
 public class TogglePreviewPopup extends JMenuItem implements ExplorerWindowSetable
 {
 
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;
@@ -61,8 +61,8 @@ public class TogglePreviewPopup extends JMenuItem implements ExplorerWindowSetab
 				return;
 			}
 
-			((StitchingExplorerPanel< ?, ? >) panel).togglePreviewMode(false);
-			
+			((StitchingExplorerPanel< ? >) panel).togglePreviewMode(false);
+
 		}
 	}
 

--- a/src/main/java/net/preibisch/stitcher/gui/popup/TogglePreviewPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/TogglePreviewPopup.java
@@ -27,8 +27,6 @@ import java.awt.event.ActionListener;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
@@ -37,11 +35,10 @@ import net.preibisch.stitcher.gui.StitchingExplorerPanel;
 public class TogglePreviewPopup extends JMenuItem implements ExplorerWindowSetable
 {
 
-	private ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
+	private ExplorerWindow< ?, ? > panel;
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/TranslateGroupManuallyPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/TranslateGroupManuallyPopup.java
@@ -45,7 +45,7 @@ import net.preibisch.stitcher.gui.TranslateGroupManuallyPanel;
 public class TranslateGroupManuallyPopup extends JMenuItem implements ExplorerWindowSetable
 {
 
-	ExplorerWindow< ?, ? > panel;
+	ExplorerWindow< ? > panel;
 
 	public TranslateGroupManuallyPopup()
 	{
@@ -75,10 +75,10 @@ public class TranslateGroupManuallyPopup extends JMenuItem implements ExplorerWi
 			final JFrame theFrame = new JFrame( "Move Views" );			
 			TranslateGroupManuallyPanel tgmp = new TranslateGroupManuallyPanel( (SpimData2) panel.getSpimData(), viewIds, panel.bdvPopup(), theFrame);
 
-			((FilteredAndGroupedExplorerPanel< AbstractSpimData<?>, ? >) panel).addListener(  tgmp );
+			((FilteredAndGroupedExplorerPanel< AbstractSpimData< ? > >) panel).addListener(  tgmp );
 
 			// re-select everything
-			ListSelectionModel lsm = ((FilteredAndGroupedExplorerPanel< ?, ? >) panel).table.getSelectionModel();
+			ListSelectionModel lsm = ((FilteredAndGroupedExplorerPanel< ? >) panel).table.getSelectionModel();
 			reSelect( lsm );
 
 			theFrame.add( tgmp );
@@ -91,10 +91,10 @@ public class TranslateGroupManuallyPopup extends JMenuItem implements ExplorerWi
 				public void windowClosing(WindowEvent e)
 				{
 					System.out.println( "closing" );
-					((FilteredAndGroupedExplorerPanel< ?, ? >) panel).getListeners().remove( tgmp );
+					((FilteredAndGroupedExplorerPanel< ? >) panel).getListeners().remove( tgmp );
 
 					// re-select everything
-					ListSelectionModel lsm = ((FilteredAndGroupedExplorerPanel< ?, ? >) panel).table.getSelectionModel();
+					ListSelectionModel lsm = ((FilteredAndGroupedExplorerPanel< ? >) panel).table.getSelectionModel();
 					reSelect( lsm );
 				}
 			});
@@ -114,7 +114,7 @@ public class TranslateGroupManuallyPopup extends JMenuItem implements ExplorerWi
 	
 	
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/TranslateGroupManuallyPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/TranslateGroupManuallyPopup.java
@@ -25,7 +25,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.event.WindowListener;
 import java.util.List;
 
 import javax.swing.JComponent;
@@ -34,25 +33,20 @@ import javax.swing.JMenuItem;
 import javax.swing.ListSelectionModel;
 
 import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.FilteredAndGroupedExplorerPanel;
-import net.preibisch.mvrecon.fiji.spimdata.explorer.SelectedViewDescriptionListener;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ApplyTransformationPopup;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
-import net.preibisch.stitcher.algorithm.SpimDataFilteringAndGrouping;
-import net.preibisch.stitcher.gui.StitchingExplorerPanel;
 import net.preibisch.stitcher.gui.TranslateGroupManuallyPanel;
-import net.preibisch.stitcher.gui.popup.TogglePreviewPopup.MyActionListener;
 
 public class TranslateGroupManuallyPopup extends JMenuItem implements ExplorerWindowSetable
 {
 
-	ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel;
-	
+	ExplorerWindow< ?, ? > panel;
+
 	public TranslateGroupManuallyPopup()
 	{
 		super( "Manually translate Views" );
@@ -120,8 +114,7 @@ public class TranslateGroupManuallyPopup extends JMenuItem implements ExplorerWi
 	
 	
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		return this;

--- a/src/main/java/net/preibisch/stitcher/gui/popup/VerifyLinksPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/VerifyLinksPopup.java
@@ -40,7 +40,7 @@ import net.preibisch.stitcher.gui.overlay.DemoLinkOverlay;
 
 public class VerifyLinksPopup extends JMenu implements ExplorerWindowSetable
 {
-	private ExplorerWindow< ?, ? > panel;
+	private ExplorerWindow< ? > panel;
 	private TogglePreviewPopup interactiveExplorer;
 	private SimpleRemoveLinkPopup parameterBasedRemoval;
 	private JMenu removeAllPopup;
@@ -118,7 +118,7 @@ public class VerifyLinksPopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
+	public JComponent setExplorerWindow( ExplorerWindow< ? > panel )
 	{
 		this.panel = panel;
 		interactiveExplorer.setExplorerWindow( panel );

--- a/src/main/java/net/preibisch/stitcher/gui/popup/VerifyLinksPopup.java
+++ b/src/main/java/net/preibisch/stitcher/gui/popup/VerifyLinksPopup.java
@@ -28,19 +28,14 @@ import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import net.imglib2.util.Pair;
-import net.imglib2.util.ValuePair;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ExplorerWindow;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.GroupedRowWindow;
-import net.preibisch.mvrecon.fiji.spimdata.explorer.StitchingResultsSettable;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.ExplorerWindowSetable;
 import net.preibisch.mvrecon.fiji.spimdata.stitchingresults.StitchingResults;
 import net.preibisch.mvrecon.process.interestpointregistration.pairwise.constellation.grouping.Group;
-import net.preibisch.stitcher.gui.StitchingExplorerPanel;
 import net.preibisch.stitcher.gui.overlay.DemoLinkOverlay;
 
 public class VerifyLinksPopup extends JMenu implements ExplorerWindowSetable
@@ -123,8 +118,7 @@ public class VerifyLinksPopup extends JMenu implements ExplorerWindowSetable
 	}
 
 	@Override
-	public JComponent setExplorerWindow(
-			ExplorerWindow< ? extends AbstractSpimData< ? extends AbstractSequenceDescription< ?, ?, ? > >, ? > panel)
+	public JComponent setExplorerWindow( ExplorerWindow< ?, ? > panel )
 	{
 		this.panel = panel;
 		interactiveExplorer.setExplorerWindow( panel );

--- a/src/main/java/net/preibisch/stitcher/headless/registration/TestGlobalOptTwoRound.java
+++ b/src/main/java/net/preibisch/stitcher/headless/registration/TestGlobalOptTwoRound.java
@@ -171,8 +171,8 @@ public class TestGlobalOptTwoRound
 			vr.updateModel();
 		}
 
-		final StitchingExplorer< SpimData2, XmlIoSpimData2 > explorer =
-				new StitchingExplorer< SpimData2, XmlIoSpimData2 >( spimData, null, null );
+		final StitchingExplorer< SpimData2 > explorer =
+				new StitchingExplorer<>( spimData, null, null );
 
 		explorer.getFrame().toFront();
 	}

--- a/src/main/java/net/preibisch/stitcher/plugin/BigStitcher.java
+++ b/src/main/java/net/preibisch/stitcher/plugin/BigStitcher.java
@@ -77,7 +77,7 @@ public class BigStitcher implements Command, PlugIn
 		final String xml = result.getXMLFileName();
 		final XmlIoSpimData2 io = result.getIO();
 
-		final StitchingExplorer< SpimData2, XmlIoSpimData2 > explorer =
+		final StitchingExplorer< SpimData2 > explorer =
 				new StitchingExplorer< >( data, xml, io );
 
 		explorer.getFrame().toFront();


### PR DESCRIPTION
Depends on https://github.com/PreibischLab/multiview-reconstruction/pull/49

- Start replacing usage of `@Deprecated` BDV API
- Simplify generics:
    - remove unnecessary `X` type parameter in
       `ExplorerWindow<AS extends AbstractSpimData<?>, X extends XmlIoAbstractSpimData<?, AS>>`
       and downstream classes.
    - remove unnecessary bounds that are already implied by the super-type's generics, e.g.,
       `AbstractSpimData<? extends AbstractSequenceDescription<? extends BasicViewSetup, ? extends BasicViewDescription<?>, ? extends BasicImgLoader>>`
       adds nothing over `AbstractSpimData<?>`