### PR TITLE
fix lazy BDV bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,9 +106,9 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<multiview-reconstruction.version>9.0.9</multiview-reconstruction.version>
+		<multiview-reconstruction.version>9.0.10-SNAPSHOT</multiview-reconstruction.version>
 
-		<!-- Mirror multiview-reconstruction 9.0.9 (zarrv3) dependency overrides so the
+		<!-- Mirror multiview-reconstruction 9.0.10 (zarrv3) dependency overrides so the
 		     transitive n5/imglib2 versions match what MVR was compiled against.
 		     TEMP: Until pom-scijava 44.0.0 is updated for ZARRv3. -->
 		<bigdataviewer-core.version>10.6.11</bigdataviewer-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<multiview-reconstruction.version>9.0.10-SNAPSHOT</multiview-reconstruction.version>
+		<multiview-reconstruction.version>9.0.10</multiview-reconstruction.version>
 
 		<!-- Mirror multiview-reconstruction 9.0.10 (zarrv3) dependency overrides so the
 		     transitive n5/imglib2 versions match what MVR was compiled against.

--- a/src/main/java/net/preibisch/stitcher/gui/StitchingExplorer.java
+++ b/src/main/java/net/preibisch/stitcher/gui/StitchingExplorer.java
@@ -46,6 +46,7 @@ import util.BDVTools;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.SelectedViewDescriptionListener;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ViewSetupExplorer;
 import net.preibisch.mvrecon.fiji.spimdata.explorer.ViewSetupExplorerPanel;
+import net.preibisch.mvrecon.fiji.spimdata.explorer.popup.BasicBDVPopup;
 import net.preibisch.stitcher.input.GenerateSpimData;
 import net.preibisch.stitcher.plugin.BigStitcher;
 
@@ -71,11 +72,6 @@ public class StitchingExplorer< AS extends SpimData2 > extends FilteredAndGroupe
 	}
 
 	public StitchingExplorer( final AS data, final URI xml, final XmlIoSpimData2 io, final boolean openBDV )
-	{
-		this( data, xml, io, openBDV, false );
-	}
-
-	public StitchingExplorer( final AS data, final URI xml, final XmlIoSpimData2 io, final boolean openBDV, final boolean startInMultiview )
 	{
 		this.data = data;
 		this.xml = xml;
@@ -132,13 +128,11 @@ public class StitchingExplorer< AS extends SpimData2 > extends FilteredAndGroupe
 		// set the initial focus to the table
 		panel.table.requestFocus();
 
+		// A single-tile dataset has nothing to stitch, so fall back to Multiview mode;
+		// otherwise always start in Stitching mode.
 		if ( panel.getTableModel().getRowCount() == 1 )
 		{
 			IOFunctions.println( "Only one tile, starting in MultiView mode." );
-			switchMode( Mode.MULTIVIEW );
-		}
-		else if ( startInMultiview )
-		{
 			switchMode( Mode.MULTIVIEW );
 		}
 	}
@@ -169,13 +163,17 @@ public class StitchingExplorer< AS extends SpimData2 > extends FilteredAndGroupe
 
 		frame.setTitle( mode == Mode.STITCHING ? "Stitching Explorer" : "Multiview Explorer" );
 		
-		// TODO: is there a smarter way than closing and reopening BDV?
-		boolean bdvWasOpen = panel.bdvPopup() != null && panel.bdvPopup().bdvRunning();
+		// Detect the running BDV via the lazy-aware accessor: getAnyBDVPopup() returns
+		// whichever BasicBDVPopup is registered (eager BDVPopup *or* a lazy popup that
+		// only implements BasicBDVPopup), whereas bdvPopup() only matches BDVPopup and
+		// would miss MVR's LazyBDVPopup on the Multiview panel.
+		final BasicBDVPopup oldPopup = panel.getAnyBDVPopup();
+		boolean bdvWasOpen = oldPopup != null && oldPopup.bdvRunning();
 		BigDataViewer bdvExisting = null;
 		if (bdvWasOpen)
 		{
-			bdvExisting = panel.bdvPopup().getBDV();
-			
+			bdvExisting = oldPopup.getBDV();
+
 			if (mode == Mode.MULTIVIEW)
 			{
 				bdvExisting.getViewer().removeTransformListener( ((StitchingExplorerPanel< AS >) panel).linkOverlay );
@@ -204,8 +202,14 @@ public class StitchingExplorer< AS extends SpimData2 > extends FilteredAndGroupe
 		frame.pack();
 
 		
-		if (bdvWasOpen && panel.bdvPopup() != null)
-			panel.bdvPopup().setBDV( bdvExisting );
+		// Hand the live BDV to the rebuilt panel's popup. getAnyBDVPopup() finds the
+		// new panel's popup even though its BDV isn't running yet (bdv == null), which
+		// bdvPopup()/runningBdvPopup() cannot do for a lazy (non-BDVPopup) popup. The
+		// lazy setBDV(...) re-wires the selection listener to the new panel; the eager
+		// setBDV(...) just adopts the instance (unchanged behavior).
+		final BasicBDVPopup newPopup = panel.getAnyBDVPopup();
+		if (bdvWasOpen && newPopup != null)
+			newPopup.setBDV( bdvExisting );
 //			for (ActionListener a : panel.bdvPopup().getActionListeners())
 //				a.actionPerformed(( new ActionEvent( this, ActionEvent.ACTION_PERFORMED, null )));
 		
@@ -227,8 +231,11 @@ public class StitchingExplorer< AS extends SpimData2 > extends FilteredAndGroupe
 		try
 		{
 			new Thread(() -> {
-				if ( panel.bdvPopup() != null && panel.bdvPopup().bdvRunning() )
-					panel.bdvPopup().closeBDV();
+				// lazy-aware: close whichever BasicBDVPopup is running (a lazy popup
+				// would be invisible to bdvPopup() and leak its BDV window otherwise).
+				final BasicBDVPopup pop = panel.getAnyBDVPopup();
+				if ( pop != null && pop.bdvRunning() )
+					pop.closeBDV();
 			}).start();
 		}
 		catch( Exception e ) {};

--- a/src/main/java/net/preibisch/stitcher/plugin/BigStitcher.java
+++ b/src/main/java/net/preibisch/stitcher/plugin/BigStitcher.java
@@ -123,14 +123,10 @@ public class BigStitcher implements Command, PlugIn
 		// Warn before unconditionally opening BDV on large datasets — it's slow and often
 		// not what the user wants. Below the threshold, behavior is unchanged (BDV opens eagerly).
 		boolean openBDV = true;
-		// Default (no dialog shown) stays Stitching mode; the advanced dialog offers an
-		// opt-in (pre-checked) to start in Multiview mode instead.
-		boolean startInMultiview = false;
 		final int totalViews = data.getSequenceDescription().getViewSetups().size() * data.getSequenceDescription().getTimePoints().size();
 		if ( advanced || totalViews > LARGE_DATASET_THRESHOLD )
 		{
 			final GenericDialog gd = new GenericDialog( "Large dataset" );
-			gd.addCheckbox( "Start_in_multiview_mode", true );
 			gd.addMessage( "This dataset has " + totalViews + " views. Opening BigDataViewer for many views can be slow." );
 			gd.addCheckbox( "Open_BigDataViewer_at_startup", totalViews < LARGE_DATASET_DISABLE_BDV_THRESHOLD );
 			gd.addCheckbox( "Use_lazy_BDV_mode (adds & removes views when selected)", totalViews >= LARGE_DATASET_LAZY_RECOMMEND_THRESHOLD );
@@ -141,7 +137,6 @@ public class BigStitcher implements Command, PlugIn
 			gd.showDialog();
 			if ( gd.wasCanceled() )
 				return;
-			startInMultiview = gd.getNextBoolean();
 			openBDV = gd.getNextBoolean();
 			BDVPopup.useLazyMode = gd.getNextBoolean();
 			InterestPointMatchCreator.maxPerPairLog = Math.max( 0, ( int ) Math.round( gd.getNextNumber() ) );
@@ -150,7 +145,7 @@ public class BigStitcher implements Command, PlugIn
 		}
 
 		final StitchingExplorer< SpimData2 > explorer =
-				new StitchingExplorer< >( data, xml, io, openBDV, startInMultiview );
+				new StitchingExplorer< >( data, xml, io, openBDV );
 
 		explorer.getFrame().toFront();
 	}


### PR DESCRIPTION
Currently, opening a dataset with lazy BDV mode and then switching to the multiview tab orphans the existing BDV process. This is because the popup's selection listener / internal source bookkeeping were still bound to the original panel.

This is part 2 of a two part fix (the other is https://github.com/JaneliaSciComp/multiview-reconstruction/pull/99.) It detects the current BDV window and passes this process upon switching modes.